### PR TITLE
Add STI to Organisation

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,7 +2,6 @@ class Organisation < ApplicationRecord
   has_one :organisation_contact
   has_one :organisation_address
 
-  has_many :placement_preferences
   has_many :user_memberships
   has_many :users, through: :user_memberships
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,0 +1,3 @@
+class Provider < Organisation
+  validates :code, presence: true, uniqueness: true
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,0 +1,5 @@
+class School < Organisation
+  validates :urn, presence: true, uniqueness: true
+
+  has_many :placement_preferences, foreign_key: :organisation_id
+end

--- a/db/migrate/20250718143326_create_organisations.rb
+++ b/db/migrate/20250718143326_create_organisations.rb
@@ -8,8 +8,7 @@ class CreateOrganisations < ActiveRecord::Migration[8.0]
       t.float :longitude
       t.float :latitude
       t.string :email_address
-      t.boolean :school
-      t.boolean :provider
+      t.string :type
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_084655) do
     t.float "longitude"
     t.float "latitude"
     t.string "email_address"
-    t.boolean "school"
-    t.boolean "provider"
+    t.string "type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_organisations_on_code"

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Organisation, type: :model do
     it { is_expected.to have_one(:organisation_contact) }
     it { is_expected.to have_one(:organisation_address) }
 
-    it { is_expected.to have_many(:placement_preferences) }
     it { is_expected.to have_many(:user_memberships) }
     it { is_expected.to have_many(:users).through(:user_memberships) }
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Provider, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:code) }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe School, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:placement_preferences) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:urn) }
+  end
+end


### PR DESCRIPTION
## Context

- Add STI inheritance so Organisations can be separated into Schools and Providers

## Changes proposed in this pull request

- Remove `:school` and `:provider` columns from `organisations table
- Add `:type` column.
- Add `School` and `Provider` models.

## Link to Trello card

https://trello.com/c/l5t4Oh20/52-sti-organisations-to-provider-school
