### PR TITLE
Add subject filter for providers

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -41,6 +41,7 @@ class OrganisationsController < ApplicationController
       :schools_to_show,
       itt_statuses: [],
       phases: [],
+      subject_ids: [],
       )
   end
 

--- a/app/forms/organisations/filter_form.rb
+++ b/app/forms/organisations/filter_form.rb
@@ -4,6 +4,7 @@ class Organisations::FilterForm < ApplicationForm
   attribute :search_location, default: nil
   attribute :search_by_name, default: nil
   attribute :phases, default: []
+  attribute :subject_ids, default: []
   attribute :itt_statuses, default: []
   attribute :schools_to_show, default: "active"
 
@@ -43,6 +44,7 @@ class Organisations::FilterForm < ApplicationForm
     {
       search_location:,
       search_by_name:,
+      subject_ids:,
       phases:,
       itt_statuses:,
       schools_to_show:
@@ -63,6 +65,10 @@ class Organisations::FilterForm < ApplicationForm
 
   def secondary_only?
     !primary_selected? && secondary_selected?
+  end
+
+  def subjects
+    PlacementSubject.parent_subjects.secondary
   end
 
   private

--- a/app/queries/schools_query.rb
+++ b/app/queries/schools_query.rb
@@ -6,6 +6,7 @@ class SchoolsQuery < ApplicationQuery
     scope = schools_to_show_condition(scope)
     scope = search_by_name_condition(scope)
     scope = phase_condition(scope)
+    scope = subject_condition(scope)
     scope = itt_statuses_condition(scope)
     order_condition(scope)
   end
@@ -23,6 +24,13 @@ class SchoolsQuery < ApplicationQuery
     return scope if filter_params[:phases].blank?
 
     scope.where(phase: filter_params[:phases])
+  end
+
+  def subject_condition(scope)
+    return scope if filter_params[:subject_ids].blank?
+
+    scope.where(
+      "(placement_preferences.placement_details #> '{secondary_subject_selection,subject_ids}') ?| array[:options]", options: filter_params[:subject_ids])
   end
 
   def filter_params
@@ -47,7 +55,7 @@ class SchoolsQuery < ApplicationQuery
     return scope if filter_params[:itt_statuses].blank?
 
     scope.where(placement_preferences: { appetite: filter_params[:itt_statuses] })
-    end
+  end
 
   def order_condition(scope)
     if params[:location_coordinates].present?

--- a/app/views/organisations/_filter.html.erb
+++ b/app/views/organisations/_filter.html.erb
@@ -44,7 +44,7 @@
           <% end %>
 
           <% if filter_form.search_by_name.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".search_by_name") %>></h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".search_by_name") %></h3>
             <ul class="app-filter-tags">
               <li>
                 <%= govuk_link_to(
@@ -71,6 +71,22 @@
                           filter: "phases",
                           value: phase,
                         ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if filter_form.subject_ids.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".subjects") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.subject_ids.each do |subject_id| %>
+                <li>
+                  <%= govuk_link_to(
+                        PlacementSubject.find(subject_id).name,
+                        filter_form.index_path_without_filter(filter: "subject_ids", value: subject_id),
                         class: "app-filter__tag",
                         no_visited_state: true,
                       ) %>
@@ -173,6 +189,19 @@
             ) do %>
               <% School.distinct.pluck(:phase).each do |phase| %>
                 <%= form.govuk_check_box :phases, phase, label: { text: phase } %>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+                  :subject_ids,
+                  legend: { text: t(".subjects"), size: "s" },
+                  small: true,
+                  multiple: true,
+                ) do %>
+              <% filter_form.subjects.each do |subject| %>
+                <%= form.govuk_check_box :subject_ids, subject.id, label: { text: subject.name } %>
               <% end %>
             <% end %>
           </div>

--- a/spec/forms/organisations/filter_form_spec.rb
+++ b/spec/forms/organisations/filter_form_spec.rb
@@ -146,6 +146,7 @@ describe Organisations::FilterForm, type: :model do
           search_location: nil,
           search_by_name: nil,
           schools_to_show: "active",
+          subject_ids: [],
           itt_statuses: [],
           phases: []
         },


### PR DESCRIPTION
## Context

Allow providers to filter by secondary school subjects.

## Changes proposed in this pull request

Add secondary subject filter

## Guidance to review

Set up a record via the add hosting interest flow with some secondary subjects
Try the filter out in browser from the provider view 

## Link to Trello card


https://trello.com/c/wFmBu0Tg/113-add-subject-filter-for-providers

## Screenshots

<img width="3584" height="4052" alt="image" src="https://github.com/user-attachments/assets/be4108f9-a7d1-4e25-a14b-dccba04fe638" />
