### PR TITLE
Update phase filter to school phase

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -6,7 +6,7 @@ en:
       search_location: Search by location
       search_by_name: Search by school name
       search_by_name_prompt: Enter a school name or URN
-      phase: Phase
+      phase: School phase
       itt_status: ITT status
       apply_filters: Apply filters
       schools_to_show: Schools to show

--- a/spec/system/organisations/provider_user_filters_schools_by_phase_spec.rb
+++ b/spec/system/organisations/provider_user_filters_schools_by_phase_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Provider user filters schools by phase", type: :system do
   end
 
   def and_i_see_the_phase_filter
-    expect(page).to have_element(:legend, text: "Phase", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:legend, text: "School phase", class: "govuk-fieldset__legend")
     expect(page).to have_unchecked_field("Primary")
     expect(page).to have_unchecked_field("Secondary")
   end


### PR DESCRIPTION
## Context

To make the filter name more clear we should use the more verbose and descriptive "School phase" rather than "Phase"

## Changes proposed in this pull request

Update content 

## Guidance to review

Check the content is correct.

## Link to Trello card

https://trello.com/c/wqNxiqS6/114-rename-phase-filter-to-school-phase

## Screenshots

<img width="339" height="946" alt="Screenshot 2025-08-14 at 14 57 49" src="https://github.com/user-attachments/assets/3c2eeb55-df8b-49ad-a2fa-79660e1e6ffe" />
