### PR TITLE
Add search distance to location filter

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -48,6 +48,7 @@ class OrganisationsController < ApplicationController
   def filter_params
     params.fetch(:filters, {}).permit(
       :search_location,
+      :search_distance,
       :search_by_name,
       :schools_to_show,
       itt_statuses: [],

--- a/app/forms/organisations/filter_form.rb
+++ b/app/forms/organisations/filter_form.rb
@@ -2,6 +2,7 @@ class Organisations::FilterForm < ApplicationForm
   include ActiveModel::Attributes
 
   attribute :search_location, default: nil
+  attribute :search_distance, default: nil
   attribute :search_by_name, default: nil
   attribute :phases, default: []
   attribute :subject_ids, default: []
@@ -12,6 +13,7 @@ class Organisations::FilterForm < ApplicationForm
     params.each_value { |v| v.compact_blank! if v.is_a?(Array) }
 
     super(params)
+    validate_search_distance
   end
 
   def filters_selected?
@@ -40,9 +42,16 @@ class Organisations::FilterForm < ApplicationForm
     )
   end
 
+  def validate_search_distance
+    if search_distance.to_i > 50
+      errors.add("Max search distance over 50 miles", "Max search distance exceeded, results capped to 50 miles")
+    end
+  end
+
   def query_params
     {
       search_location:,
+      search_distance:,
       search_by_name:,
       subject_ids:,
       phases:,
@@ -79,3 +88,5 @@ class Organisations::FilterForm < ApplicationForm
     @compacted_attributes ||= attributes.compact_blank
   end
 end
+
+class InvalidSearchDistanceError < StandardError; end

--- a/app/queries/schools_query.rb
+++ b/app/queries/schools_query.rb
@@ -40,7 +40,7 @@ class SchoolsQuery < ApplicationQuery
   def organisation_ids_near_location(location_coordinates)
     Organisation.near(
       location_coordinates,
-      MAX_LOCATION_DISTANCE,
+      max_radius,
       order: :distance,
     ).map(&:id)
   end
@@ -70,6 +70,14 @@ class SchoolsQuery < ApplicationQuery
            .order(Arel.sql("ordering_index"))
     else
       scope.distinct.order(:name)
+    end
+  end
+
+  def max_radius
+    if filter_params[:search_distance].present?
+      [ filter_params[:search_distance].to_i, MAX_LOCATION_DISTANCE ].compact.min
+    else
+      MAX_LOCATION_DISTANCE
     end
   end
 end

--- a/app/views/organisations/_filter.html.erb
+++ b/app/views/organisations/_filter.html.erb
@@ -1,5 +1,13 @@
 <div class="app-filter-layout display-none-on-mobile " data-filter-target="filter">
   <div class="app-filter-layout__filter">
+          <%= form_with(
+              model: filter_form,
+              scope: :filters,
+              url: organisations_path,
+              method: "get",
+            ) do |form| %>
+            <%= form.govuk_error_summary %>
+      <% end %>
     <div class="app-filter__header">
       <div class="app-filter__header-title">
         <h2 class="govuk-heading-m"><%= t(".filters") %></h2>
@@ -135,6 +143,11 @@
                 <%= form.govuk_text_field :search_location, type: :search, value: @search_location, label: { hidden: true }, caption: { text: "Enter a town, city or postcode" } %>
                 <p class="govuk-body-s secondary-text"><%= t(".powered_by_google") %></p>
               </div>
+              <% if @search_location.present? %>
+                <div class="govuk-form-group">
+                  <%= form.govuk_text_field :search_distance, type: :number, label: { hidden: true }, caption: { text: "Enter a max distance from your search location" }, suffix_text: 'miles' %>
+                </div>
+              <% end %>
             </div>
           </div>
 

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,4 +1,7 @@
-<%= content_for :page_title, t(".title") %>
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: filter_form.errors.any?,
+) %>
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -84,3 +84,4 @@ en:
       distance: Distance
       travel_time: Travel time
       no_results: There are no schools that match your selection. Try searching again, or removing one or more filters.
+      max_search_distance_error: Search distance must be 50 miles or less, results capped to 50 miles.

--- a/spec/forms/organisations/filter_form_spec.rb
+++ b/spec/forms/organisations/filter_form_spec.rb
@@ -24,6 +24,24 @@ describe Organisations::FilterForm, type: :model do
       end
     end
 
+    context "when given search distance params" do
+      context "when search location an empty string" do
+        let(:params) { { search_distance: "" } }
+
+        it "return false" do
+          expect(filters_selected).to be(false)
+        end
+      end
+
+      context "when search location not an empty string" do
+        let(:params) { { search_distance: "20" } }
+
+        it "return true" do
+          expect(filters_selected).to be(true)
+        end
+      end
+    end
+
     context "when given search by name params" do
       context "when search by name an empty string" do
         let(:params) { { search_by_name: "" } }
@@ -145,6 +163,7 @@ describe Organisations::FilterForm, type: :model do
         {
           search_location: nil,
           search_by_name: nil,
+          search_distance: nil,
           schools_to_show: "active",
           subject_ids: [],
           itt_statuses: [],

--- a/spec/queries/schools_query_spec.rb
+++ b/spec/queries/schools_query_spec.rb
@@ -95,6 +95,14 @@ describe SchoolsQuery do
         expect(query.call).to eq([ query_school, close_query_school, far_query_school ])
         expect(query.call).not_to include(non_query_school)
       end
+
+      context "when specifying a max distance" do
+        let(:params) { { location_coordinates:, filters: { schools_to_show: "all", search_distance: 1 } } }
+
+        it "returns the filtered schools in order of distance" do
+          expect(query.call).to contain_exactly(query_school, close_query_school)
+        end
+      end
     end
 
     context "when filtering schools by placement preferences" do


### PR DESCRIPTION
## Context

We default the search location radius to be 50 miles, we should create a filter for this that allows users to change this radius as required.

Do not let the user exceed 50 miles, this will remain the upper limit, I’d recommend we make use of a number input and only allow whole numbers from 1-50.


## Changes proposed in this pull request

Add a new filter option to allow users to change their search radius

## Guidance to review

Test the filter works

## Link to Trello card

https://trello.com/c/wAIchM3Q/120-add-location-search-radius-filter

## Screenshots

<img width="3584" height="4732" alt="image" src="https://github.com/user-attachments/assets/61894f46-503e-4419-ad3b-8a4cbd990f97" />

When filtering to 4 miles:
<img width="3584" height="4272" alt="image" src="https://github.com/user-attachments/assets/1cc481c3-52c2-4016-9c12-1beac120fc79" />
