### PR TITLE
Add footer pages to find itt placements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ gem "stimulus-rails", "~> 1.3"
 
 gem "ostruct", "~> 0.6.1"
 
+# Markdown
+gem "govuk_markdown"
+gem "redcarpet", "~> 3.6"
+
 # DfE Sign-in
 gem "omniauth"
 gem "omniauth_openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,9 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 1)
+    govuk_markdown (2.0.3)
+      activesupport
+      redcarpet
     hashdiff (1.2.0)
     hashie (5.0.0)
     html-attributes-utils (1.0.2)
@@ -428,6 +431,7 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redcarpet (3.6.1)
     regexp_parser (2.10.0)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -649,6 +653,7 @@ DEPENDENCIES
   geocoder (~> 1.8)
   govuk-components
   govuk_design_system_formbuilder
+  govuk_markdown
   httparty (~> 0.23.1)
   jsbundling-rails
   kamal
@@ -665,6 +670,7 @@ DEPENDENCIES
   rails (~> 8.0.2)
   rails-controller-testing
   rails_semantic_logger
+  redcarpet (~> 3.6)
   rladr
   rspec
   rspec-rails

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,16 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!
+  PAGES_DIR = Rails.root.join("app", "views", "pages").freeze
 
   def home; end
+
+  def show
+    page = params[:page].to_s
+    base = PAGES_DIR.to_s
+    path = File.expand_path("#{page}.md", base)
+    render locals: {
+      page:,
+      content: File.read(path)
+    }
+  end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -1,0 +1,10 @@
+module FooterHelper
+  def footer_meta_items
+    [
+      { text: t(".accessibility"), href: accessibility_path },
+      { text: t(".cookies"), href: cookies_path },
+      { text: t(".privacy_policy"), href: privacy_path },
+      { text: t(".terms_and_conditions"), href: terms_and_conditions_path }
+    ]
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,5 @@
+module MarkdownHelper
+  def render_markdown(content, headings_start_with: "l")
+    GovukMarkdown.render(content, headings_start_with:).html_safe
+  end
+end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,19 @@
+<%= govuk_footer meta_items: footer_meta_items, meta_licence: false do |footer| %>
+  <%= footer.with_content_before_meta_items do %>
+    <h3 class="govuk-heading-m"><%= t(".get_help") %></h3>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h4 class="govuk-heading-3 govuk-!-margin-top-0 govuk-!-margin-bottom-1"><%= t(".email.heading") %></h4>
+
+        <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
+          <%= govuk_footer_link_to t(".support_email_html"), "mailto:#{t(".support_email")}?subject=#{t(".service_name")}%20support" %>
+        </p>
+
+        <p class="govuk-!-font-size-16">
+          <%= t(".email.disclaimer_html") %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,6 @@
       <%= yield %>
     </main>
 
-    <%= govuk_footer %>
+    <%= render "layouts/footer" %>
   </body>
 </html>

--- a/app/views/pages/accessibility.md
+++ b/app/views/pages/accessibility.md
@@ -1,0 +1,59 @@
+# Accessibility statement for Find ITT placements
+
+This accessibility statement applies to the Find ITT placements website.
+
+This website is run by the Department for Education. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
+-   change colours, contrast levels and fonts
+-   zoom in up to 400% without the text spilling off the screen
+-   navigate most of the website using just a keyboard
+-   navigate most of the website using speech recognition software
+-   listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We've also made the website text as simple as possible to understand.
+
+<a href="https://mcmw.abilitynet.org.uk/" target="_blank" rel="noopener">AbilityNet (opens in a new tab)</a> has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible:
+
+-  Unsupported aria attributes. It is important to ensure that an element’s role supports its ARIA attributes. This fails WCAG Level A 2.2: 4.1.2 Name, Role, Value. This issue is being tracked by the GOV.UK Design System team as part a wider issue beyond our service – our implementation currently follows their guidance and any future changes they recommend regarding this issue will be implemented in this service.
+
+## Feedback and contact information
+
+If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, email [manage.schoolplacements@education.gov.uk](mailto:manage.schoolplacements@education.gov.uk). We’ll consider your request and get back to you in 5 working days.
+
+## Reporting accessibility problems with this website
+
+We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, email [manage.schoolplacements@education.gov.uk](mailto:manage.schoolplacements@education.gov.uk). We’ll consider your request and get back to you in 5 working days.
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/" target="_blank" rel="noopener">contact the Equality Advisory and Support Service (opens in a new tab)</a>.
+
+## Technical information about this website’s accessibility
+
+The Department for Education is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the WCAG (Web Content Accessibility Guidelines) version 2.2 AA standard, due to the following non-compliances (and/or) the following exemptions.
+
+#### Non-compliance with the accessibility regulations
+
+Unsupported aria attributes. It is important to ensure that an element’s role supports its ARIA attributes. This does not meet <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html" target="_blank" rel="noopener">WCAG version 2.2 AA - 1.1.1 Non-text Content (opens in a new tab)</a>.
+
+This issue is being tracked by the GOV.UK Design System team as part a wider issue beyond our service – our implementation currently follows their guidance and any future changes they recommend regarding this issue will be implemented in this service.
+
+## What we’re doing to improve accessibility
+
+We will continue to review feedback provided via the feedback link or through queries sent to [manage.schoolplacements@education.gov.uk](mailto:manage.schoolplacements@education.gov.uk) to inform improvements to the service.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 15/10/2024. It was last reviewed on 20/02/2025.
+
+This website was last tested on 14/10/2024. The test was carried out by Zoonou. Zoonou used <a href="https://www.w3.org/TR/WCAG-EM/" target="_blank" rel="noopener">WCAG-EM (opens in a new tab)</a> to define the pages tested and test approach.
+
+Accessibility statement version: 2.0.0

--- a/app/views/pages/cookies.md
+++ b/app/views/pages/cookies.md
@@ -1,0 +1,17 @@
+# Cookies on Find ITT placements
+
+Cookies are small files saved on your phone, tablet or computer when you visit a website.
+
+We use cookies to make Find ITT placements work.
+
+## Essential cookies
+
+Essential cookies keep your information secure while you use Find ITT placements work. We do not need to ask permission to use them.
+
+| Name | Purpose | Expires |
+| -------- | -------- | -------- |
+| _itt_mentor_services_session | Session cookie to identify the user of the service and their place on multi-step form journeys. | When the user's browser is closed. |
+
+Read more about how we process personal data in our [privacy notice](/privacy).
+
+Last updated 10 May 2024

--- a/app/views/pages/privacy.md
+++ b/app/views/pages/privacy.md
@@ -1,0 +1,7 @@
+# Find ITT placements privacy notice
+
+Read the [Privacy information: education providers’ workforce, including teachers](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers).
+
+[Section 8.4](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-maintain-a-list-of-teachers) tells you what we do with you and your mentor’s data when you make contact with us or use this service.
+
+[Section 4.1](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-datato-contact-you-for-feedback) tells you how we use your data to contact you for feedback.

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,15 @@
+<% content_for :breadcrumbs, govuk_breadcrumbs(
+  breadcrumbs: {
+    t("home") => root_path,
+  },
+  collapse_on_mobile: true,
+) %>
+<% content_for :page_title, t(".#{page}.page_title") %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render_markdown(content) %>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/terms_and_conditions.md
+++ b/app/views/pages/terms_and_conditions.md
@@ -1,0 +1,89 @@
+# Terms and conditions
+## Using our website
+
+Please read these Terms of Use (“General Terms”) carefully before using this Find ITT placements service (the “Service”).
+
+This service is maintained to enable:
+
+- Schools to publish placement opportunities for trainee teachers so that teacher training providers can contact them
+- Teacher training providers to find schools who are offering placements for trainee teachers
+
+Access and use by you of this Service constitutes your acceptance of these General Terms. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
+
+If we change these General Terms we will post the revised document here with an updated effective date. If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
+
+## Information about us
+This Service is operated by the Department for Education (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
+
+You can contact us using the following email address:
+[manage.schoolplacements@education.gov.uk](mailto:manage.schoolplacements@education.gov.uk)
+
+## Access to the Service
+We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Service to users who have registered with us.
+
+If you choose, or are provided with, a user verification code, password or any other piece of information as part of our security procedures, you must treat such information as confidential, and you must not disclose it to any third party.
+
+We reserve the right to restrict or deny you access to all or some part of the Service if in our opinion you have failed to comply with the General Terms.
+
+The Department for Education withholds the right to withdraw the access of users who breach them.
+
+## Hyperlinking to the Find ITT placements website
+We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Find ITT placements’ pages must be displayed in the user’s entire browser window.
+
+You may not charge your website’s users to click on a link to any page on the Service.
+
+## Third party content and hyperlinking from the Service
+We are not liable or responsible for the third party content on the Service. Third party content includes, for example, material posted by other users of the Service.
+
+Where the Service contains links to other sites and resources, we are not liable or responsible for the content or reliability of those websites and resources and do not necessarily endorse the views expressed within them.
+
+We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
+
+## Virus protection
+We make every effort to check and test material at all stages of production. We do not guarantee our service will be secure or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
+
+We will report misuse, unauthorised access or other breaches of the [Computer Misuse Act 1990](https://www.legislation.gov.uk/ukpga/1990/18/contents) to the relevant law enforcement authorities and co-operate with them to determine your identity.
+
+## Disclaimer and liability
+The content of this Service includes both content created by us (included but not limited to content that helps you use the Service) and third-party content including information about teacher reference numbers (TRNs). We do not:
+
+- endorse third-party content
+- vouch for its accuracy
+- guarantee that the views, instructions and/or assertions expressed in it are our own
+
+The content we create for the Service is not advice. You should verify any information on the Service yourself and use your own judgement before doing or not doing anything on the basis of the content.
+
+Unless expressly stated in writing by us, the Service and material relating to government information, products and services (or to third party information, products and services), is provided ‘as is’, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.
+
+We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials.
+
+In no event will we be liable for:
+
+- any action you may take as a result of relying on any information or materials provided on the Service or for any loss or damage suffered by you as a result of you taking such action including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of the Service
+- any dealings you have with third parties, like other users, that take place using or facilitated by the Service
+
+## Validity of these General Terms
+If any of these General Terms are held to be invalid, unenforceable or illegal for any reason, the remaining General Terms will still apply.
+
+## Applicable law and jurisdiction
+These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
+
+## Using the Service
+Access and use by you of this Service constitutes your acceptance of these General Terms.
+
+By using this Service you agree to abide by the following terms and conditions.
+
+## Unacceptable use
+You must not add a mentor to the service without informing them that the Department for Education will store their information in line with the [privacy notice](/privacy) and have provided them with a copy of this notice for reference.
+
+## Mentor and placement data
+Data ownership: schools have sole responsibility for maintaining the accuracy and appropriateness of their mentor and placement data contained in the Service and associated contact details.
+
+## Privacy
+Read the Privacy information: [education providers’ workforce, including teachers (opens in new tab)](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers).
+
+[Section 8.4 (opens in new tab)](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-maintain-a-list-of-teachers) tells you what we do with you and your mentor’s data when you make contact with us or use this service.
+
+[Section 4.1 (opens in new tab)](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-datato-contact-you-for-feedback) tells you how we use your data to contact you for feedback.
+
+Last updated 10 June 2024

--- a/config/locales/en/layouts/footer.yml
+++ b/config/locales/en/layouts/footer.yml
@@ -1,0 +1,18 @@
+en:
+  layouts:
+    footer:
+      get_help: Get help
+      support_email_html: placeholder@sample.com
+      support_email: placeholder@sample.com
+      service_name: Find ITT placements
+
+      email:
+        heading: Email
+        disclaimer_html: You’ll get a response within 5 working days.
+
+      grant_conditions: Grant conditions
+      guidance: Guidance
+      accessibility: Accessibility
+      cookies: Cookies
+      privacy_policy: Privacy notice
+      terms_and_conditions: Terms and conditions

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -1,0 +1,11 @@
+en:
+  pages:
+    show:
+      cookies:
+        page_title: Cookies on Find ITT placements
+      accessibility:
+        page_title: Accessibility statement for Find ITT placements
+      privacy:
+          page_title: Privacy notice for Find ITT placements
+      terms_and_conditions:
+        page_title: Terms and conditions for Find ITT placements

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,13 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "sessions#failure"
   end
 
+  scope module: :pages do
+    get :cookies, action: :show, page: :cookies
+    get :privacy, action: :show, page: :privacy
+    get :accessibility, action: :show, page: :accessibility
+    get :terms_and_conditions, action: :show, page: :terms_and_conditions
+  end
+
   get "/.well-known/appspecific/com.chrome.devtools.json", to: proc { [ 204, {}, [ "" ] ] }
 
   resources :organisations, only: %i[show index]

--- a/spec/system/pages/user_views_the_accessibility_page_spec.rb
+++ b/spec/system/pages/user_views_the_accessibility_page_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "User views accessibility page", type: :system do
+  scenario do
+    given_i_navigate_to_the_service
+    and_i_click_on_accessibility
+    then_i_see_the_accessibility_page
+  end
+
+  private
+
+  def given_i_navigate_to_the_service
+    visit root_path
+  end
+
+  def and_i_click_on_accessibility
+    click_on "Accessibility"
+  end
+
+  def then_i_see_the_accessibility_page
+    expect(page).to have_title("Accessibility statement for Find ITT placements - Find ITT placements")
+    expect(page).to have_h1("Accessibility statement for Find ITT placements")
+    expect(page).to have_h2("How accessible this website is")
+    expect(page).to have_h2("Feedback and contact information")
+  end
+end

--- a/spec/system/pages/user_views_the_cookies_page_spec.rb
+++ b/spec/system/pages/user_views_the_cookies_page_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "User views cookies page", type: :system do
+  scenario do
+    given_i_navigate_to_the_service
+    and_i_click_on_cookies
+    then_i_see_the_cookies_page
+  end
+
+  private
+
+  def given_i_navigate_to_the_service
+    visit root_path
+  end
+
+  def and_i_click_on_cookies
+    click_on "Cookies"
+  end
+
+  def then_i_see_the_cookies_page
+    expect(page).to have_title("Cookies on Find ITT placements - Find ITT placements")
+    expect(page).to have_h1("Cookies on Find ITT placements")
+    expect(page).to have_h2("Essential cookies")
+  end
+end

--- a/spec/system/pages/user_views_the_privacy_page_spec.rb
+++ b/spec/system/pages/user_views_the_privacy_page_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "User views privacy page", type: :system do
+  scenario do
+    given_i_navigate_to_the_service
+    and_i_click_on_privacy
+    then_i_see_the_privacy_page
+  end
+
+  private
+
+  def given_i_navigate_to_the_service
+    visit root_path
+  end
+
+  def and_i_click_on_privacy
+    click_on "Privacy"
+  end
+
+  def then_i_see_the_privacy_page
+    expect(page).to have_title("Privacy notice for Find ITT placements - Find ITT placements")
+    expect(page).to have_h1("Find ITT placements privacy notice")
+    expect(page).to have_paragraph("Read the Privacy information: education providers’ workforce, including teachers.")
+  end
+end

--- a/spec/system/pages/user_views_the_terms_and_conditions_page_spec.rb
+++ b/spec/system/pages/user_views_the_terms_and_conditions_page_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "User views terms_and_conditions page", type: :system do
+  scenario do
+    given_i_navigate_to_the_service
+    and_i_click_on_terms_and_conditions
+    then_i_see_the_terms_and_conditions_page
+  end
+
+  private
+
+  def given_i_navigate_to_the_service
+    visit root_path
+  end
+
+  def and_i_click_on_terms_and_conditions
+    click_on "Terms and conditions"
+  end
+
+  def then_i_see_the_terms_and_conditions_page
+    expect(page).to have_title("Terms and conditions for Find ITT placements - Find ITT placements")
+    expect(page).to have_h2("Using our website")
+    expect(page).to have_h2("Information about us")
+    expect(page).to have_h2("Access to the Service")
+    expect(page).to have_h2("Hyperlinking to the Find ITT placements website")
+  end
+end


### PR DESCRIPTION
## Context

The accessibility; cookies; privacy and Terms and conditions pages are required before we can launch the service. They have been added to the footer.

## Changes proposed in this pull request

Add pages to footer. 

## Guidance to review

Check the pages load correctly.

## Link to Trello card

https://trello.com/c/x23Utfy8/138-add-privacy-policy-tcs-etc-to-the-new-service

## Screenshots

<img width="3095" height="8076" alt="image" src="https://github.com/user-attachments/assets/156c2e85-9cfc-47f2-8451-492333c661cc" />
<img width="3584" height="5882" alt="image" src="https://github.com/user-attachments/assets/36db91d2-319c-46f9-a7a4-2279327e8c00" />
<img width="3584" height="2286" alt="image" src="https://github.com/user-attachments/assets/ab68aab8-f33d-4ce4-ab3e-d6421b8f4cc4" />
<img width="3584" height="2064" alt="image" src="https://github.com/user-attachments/assets/3b63ba5e-4544-4e0d-8a00-6b20c93bb36e" />

