### PR TITLE
Add appetite selection to EOI check your answers

### DIFF
--- a/app/views/shared/wizards/hosting_interest/_check_your_answers.html.erb
+++ b/app/views/shared/wizards/hosting_interest/_check_your_answers.html.erb
@@ -1,4 +1,18 @@
 <%# locals: { current_step:, wizard:, potential: false } -%>
+<h2 class="govuk-heading-m">
+  <%= t(".offering_placements") %>
+</h2>
+
+<%= govuk_summary_list(html_attributes: { id: "placement_availability" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".can_your_school_offer_placements")) %>
+    <% row.with_value(text: t("wizards.add_hosting_interest_wizard.appetite_step.options.#{current_step.appetite}.name")) %>
+    <% row.with_action(text: t("change"),
+                       href: step_path(:appetite),
+                       visually_hidden_text: t(".availability_to_offer_placements"),
+                       classes: ["govuk-link--no-visited-state"]) %>
+  <% end %>
+<% end %>
 
 <h2 class="govuk-heading-m">
   <%= t(".education_phase") %>

--- a/app/views/wizards/add_hosting_interest_wizard/_are_you_sure_step.html.erb
+++ b/app/views/wizards/add_hosting_interest_wizard/_are_you_sure_step.html.erb
@@ -21,6 +21,14 @@
 
       <%= govuk_summary_list(html_attributes: { id: "reason_for_not_offering" }) do |summary_list| %>
         <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".can_your_school_offer_placements")) %>
+          <% row.with_value(text: t("wizards.add_hosting_interest_wizard.appetite_step.options.#{current_step.appetite}.name")) %>
+          <% row.with_action(text: t("change"),
+                             href: step_path(:appetite),
+                             visually_hidden_text: t(".availability_to_offer_placements"),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".reason_for_not_offering")) %>
           <% row.with_value do %>
             <%= govuk_list do %>

--- a/app/wizards/add_hosting_interest_wizard/are_you_sure_step.rb
+++ b/app/wizards/add_hosting_interest_wizard/are_you_sure_step.rb
@@ -1,4 +1,5 @@
 class AddHostingInterestWizard::AreYouSureStep < BaseStep
+  delegate :appetite, to: :appetite_step
   delegate :first_name, :last_name, :email_address, to: :school_contact_step, prefix: :school_contact
   delegate :reasons_not_hosting, :other_reason_not_hosting, to: :reason_not_hosting_step
 
@@ -10,5 +11,9 @@ class AddHostingInterestWizard::AreYouSureStep < BaseStep
 
   def reason_not_hosting_step
     wizard.steps.fetch(:reason_not_hosting)
+  end
+
+  def appetite_step
+    wizard.steps.fetch(:appetite)
   end
 end

--- a/app/wizards/add_hosting_interest_wizard/check_your_answers_step.rb
+++ b/app/wizards/add_hosting_interest_wizard/check_your_answers_step.rb
@@ -1,5 +1,6 @@
 class AddHostingInterestWizard::CheckYourAnswersStep < BaseStep
   delegate :phases, to: :phase_step
+  delegate :appetite, to: :appetite_step
   delegate :year_groups, :selected_secondary_subjects, :key_stages, :step_name_for_child_subjects, to: :wizard
   delegate :first_name, :last_name, :email_address, to: :school_contact_step, prefix: :school_contact
 
@@ -17,5 +18,9 @@ class AddHostingInterestWizard::CheckYourAnswersStep < BaseStep
 
   def school_contact_step
     wizard.steps.fetch(:school_contact)
+  end
+
+  def appetite_step
+    wizard.steps.fetch(:appetite)
   end
 end

--- a/config/locales/en/shared/wizards/hosting_interest.yml
+++ b/config/locales/en/shared/wizards/hosting_interest.yml
@@ -3,6 +3,8 @@ en:
     wizards:
       hosting_interest:
         check_your_answers:
+          offering_placements: Offering placements
+          can_your_school_offer_placements: Can your school offer placements for trainee teachers?
           education_phase: Education phase and specialism
           primary_placements: Primary placements
           primary: Primary

--- a/config/locales/en/wizards/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/add_hosting_interest_wizard.yml
@@ -115,6 +115,7 @@ en:
           Your reason for not offering placements will be shared with the Department for Education to help understand teacher training and recruitment.
         reason_for_not_offering: Reason for not offering
         details: Details
+        can_your_school_offer_placements: Can your school offer placements for trainee teachers?
         itt_contact: Placement contact
         continue: Continue
         change: Change

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -181,7 +181,13 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement information #{@next_academic_year_short_name}")
     expect(page).to have_h1("Check your answers")
 
-     expect(page).to have_h2("Education phase and specialism")
+    expect(page).to have_h2("Offering placements")
+    expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "Yes",
+    )
+
+    expect(page).to have_h2("Education phase and specialism")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary Send")
 
     expect(page).to have_h2("Primary placements")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -259,7 +259,13 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement information #{@next_academic_year_short_name}")
     expect(page).to have_h1("Check your answers")
 
-     expect(page).to have_h2("Education phase and specialism")
+    expect(page).to have_h2("Offering placements")
+    expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "Yes",
+    )
+
+    expect(page).to have_h2("Education phase and specialism")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary Send")
 
     expect(page).to have_h2("Primary placements")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_including_a_child_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_including_a_child_subject_spec.rb
@@ -202,6 +202,12 @@ RSpec.describe "School user successfully adds their hosting interest, including 
     expect(page).to have_caption("Placement information #{@next_academic_year_short_name}")
     expect(page).to have_h1("Check your answers")
 
+    expect(page).to have_h2("Offering placements")
+    expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "Yes",
+    )
+
     expect(page).to have_h2("Education phase and specialism")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary Send")
 

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -182,6 +182,12 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement information #{@next_academic_year_short_name}")
     expect(page).to have_h1("Check your answers")
 
+    expect(page).to have_h2("Offering placements")
+    expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "Yes",
+    )
+
     expect(page).to have_h2("Education phase and specialism")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary Send")
 

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -184,6 +184,12 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement information #{@next_academic_year_short_name}")
     expect(page).to have_h1("Check your answers")
 
+    expect(page).to have_h2("Offering placements")
+    expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "Yes",
+    )
+
     expect(page).to have_h2("Education phase and specialism")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary Send")
 

--- a/spec/system/placement_preferences/add_hosting_interest/interested/school_user_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/interested/school_user_adds_their_hosting_interest_spec.rb
@@ -296,7 +296,13 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     )
     expect(page).to have_h1("Check your answers")
 
-     expect(page).to have_h2("Education phase and specialism")
+    expect(page).to have_h2("Offering placements")
+    expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "Maybe",
+    )
+
+    expect(page).to have_h2("Education phase and specialism")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary Send")
 
     expect(page).to have_h2("Primary")

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -185,6 +185,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
   def and_i_see_the_reason_not_hosting_i_entered
     expect(page).to have_summary_list_row(
+      "Can your school offer placements for trainee teachers?",
+      "No",
+    )
+    expect(page).to have_summary_list_row(
       "Reason for not offering",
       "Other - Some other reason",
     )


### PR DESCRIPTION
## Context

- Add appetite selection to EOI check your answers page

## Changes proposed in this pull request

- Add appetite selection to EOI check your answers page

## Guidance to review

- Sign in as Anne (School user)
- ⚠️ If you have not yet completed an EOI, the EOI wizard will appear, otherwise, visit placement_preferences/new ⚠️
- Complete the EOI journeys and make sure the selected appetite shows on the check your answers page.

## Link to Trello card

https://trello.com/c/ArVtbcVG/183-add-yes-maybe-no-selection-to-the-check-your-answers-pages-in-all-eoi-flows-with-change-links

## Screenshots

_Yes_

<img width="663" height="260" alt="Screenshot 2025-09-12 at 15 54 59" src="https://github.com/user-attachments/assets/6d013c39-1b56-48be-a432-051ad804025b" />

_Maybe_

<img width="654" height="263" alt="Screenshot 2025-09-12 at 15 55 40" src="https://github.com/user-attachments/assets/f2b1b6bd-e646-4f99-93de-770a72269ae2" />

_No_

<img width="666" height="561" alt="Screenshot 2025-09-12 at 15 56 37" src="https://github.com/user-attachments/assets/d451defc-b202-40ab-9d35-0115245d48ba" />

