### PR TITLE
Pin libcrypto3 to 3.5.6-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apk add --update --no-cache tzdata && \
 # postgresql-dev: postgres driver and libraries
 # git: to install dfe-analytics
 # yaml-dev: psych issues
-RUN apk add --no-cache build-base yarn postgresql17-dev git yaml-dev
+# https://security.snyk.io/vuln/SNYK-ALPINE323-OPENSSL-15993266
+RUN apk add --no-cache build-base yarn postgresql17-dev git yaml-dev libcrypto3=3.5.6-r0
 
 RUN apk add --no-cache nodejs npm
 
@@ -80,6 +81,9 @@ RUN apk add --no-cache libpq
 
 # proj-util: provides cs2cs, required by Gias::CSVTransformer::CoordinateTransformer
 RUN apk add --no-cache proj-util
+
+# https://security.snyk.io/vuln/SNYK-ALPINE323-OPENSSL-15993266
+RUN apk add --no-cache libcrypto3=3.5.6-r0
 
 # Copy files generated in the builder image
 COPY --from=builder /app /app


### PR DESCRIPTION
## Context

https://security.snyk.io/vuln/SNYK-ALPINE323-OPENSSL-15993266

## Changes proposed in this pull request

Pin libcrypto3 to 3.5.6-r0

## Guidance to review

see successful workflows run by this PR
