### PR TITLE
Add the missed data syncs to the service

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -26,3 +26,12 @@ production:
   sync_bank_holidays:
     schedule: every day at 2am
     class: "BankHolidays::SyncJob"
+  sync_all_schools:
+    schedule: every day at 3am
+    class: "GIAS::SyncAllSchoolsJob"
+  sync_all_subjects:
+    schedule: every day at 1am
+    class: "PublishTeacherTraining::Subject::SyncAllJob"
+  sync_all_providers:
+    schedule: every day at 1am
+    class: "PublishTeacherTraining::Provider::SyncAllJob"


### PR DESCRIPTION
## Context

GIAS syncs were not running, upon investigating it became apparent that a few of the daily syncs had been missed from the recurring tasks file.

## Changes proposed in this pull request

- Adds the GIAS sync 
- Adds the Subject sync
- Adds the provider sync

## Guidance to review

- Compare the class names to the sync files and ensure they are correct

## Link to Trello card

https://trello.com/c/VDaPLUmF/347-fix-gias-sync-and-check-other-syncs
