### PR TITLE
Update placement contact text to be more descriptive

### DIFF
--- a/config/locales/en/wizards/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/add_hosting_interest_wizard.yml
@@ -106,7 +106,7 @@ en:
       school_contact_step:
         caption: Placement contact
         title: Who should providers contact?
-        description: Choose the person best placed to organise placements for trainee teachers at your school.
+        description: Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.
         continue: Continue
       check_your_answers_step:
         caption: Placement information %{academic_year_name}
@@ -202,5 +202,5 @@ en:
           caption: Placement contact
           title: Who can we contact in your school?
           we_will_ask_next_year: We will email to ask if your school can offer placements for trainee teachers in future academic years.
-          choose_the_best_person: Choose the person best placed to organise placements for trainee teachers at your school.
+          choose_the_best_person: Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.
           continue: Continue

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_enter_school_contact_details_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_enter_school_contact_details_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "School user does not enter school contact details", type: :syste
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "School user does not select a year group", type: :system do
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "School user does not select a phase", type: :system do
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "School user successfully adds their hosting interest, including 
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_including_a_child_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_including_a_child_subject_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "School user successfully adds their hosting interest, including 
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_does_not_select_a_key_stage_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_does_not_select_a_key_stage_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "School user does not select a key stage", type: :system do
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/interested/school_user_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/interested/school_user_adds_their_hosting_interest_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/interested/school_user_does_not_know_their_phase_preference_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/interested/school_user_does_not_know_their_phase_preference_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_another_reason_for_not_hosting_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_another_reason_for_not_hosting_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "School user does not enter another reason for not hosting", type
       "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
     )
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school.",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
     )
 
     expect(page).to have_field("First name")

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_school_contact_details_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_school_contact_details_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
       "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
     )
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school.",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
     )
 
     expect(page).to have_field("First name")

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_select_a_reason_for_not_hosting_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_select_a_reason_for_not_hosting_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "School user does not select a reason for not hosting", type: :sy
       "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
     )
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school.",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
     )
 
     expect(page).to have_field("First name")

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
       "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
     )
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school.",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
     )
 
     expect(page).to have_field("First name")

--- a/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_to_actively_looking_spec.rb
+++ b/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_to_actively_looking_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe "School user updates the placement preference to actively looking
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_to_interested_spec.rb
+++ b/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_to_interested_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe "School user updates the placement preference to interest", type:
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
     )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_to_not_open_spec.rb
+++ b/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_to_not_open_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
       "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
     )
     expect(page).to have_hint(
-      "Choose the person best placed to organise placements for trainee teachers at your school.",
+      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
     )
 
     expect(page).to have_field("First name")

--- a/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_with_an_invalid_value_spec.rb
+++ b/spec/system/placement_preferences/edit_hosting_interest/school_user_updates_the_placement_preference_with_an_invalid_value_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "School user updates the placement preference with an invalid val
     expect(page).to have_caption("Placement contact")
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_hint(
-                      "Choose the person best placed to organise placements for trainee teachers at your school",
+                      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school",
                       )
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")

--- a/spec/system/placement_preferences/school_user_creates_multiple_placement_preferences_spec.rb
+++ b/spec/system/placement_preferences/school_user_creates_multiple_placement_preferences_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "School user creates multiple placement preferences", type: :syst
                       "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
                       )
     expect(page).to have_hint(
-                      "Choose the person best placed to organise placements for trainee teachers at your school.",
+                      "Choose the person best placed to organise placements for trainee teachers at your school. The person should be aware you are adding their details and expect to be contacted by ITT providers interested in placing trainees at your school.",
                       )
 
     expect(page).to have_field("First name")


### PR DESCRIPTION
## Context

There was some confusion about who should be added as a placement contact, these changes should improve clarity.

## Changes proposed in this pull request

- Updates the user facing text when adding a new placement contact.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/kpsNu4GZ/387-add-content-in-the-placement-contact-section-to-ensure-contact-listed-is-aware

## Screenshots

<img width="806" height="717" alt="image" src="https://github.com/user-attachments/assets/19b20cd7-833d-4c7f-b973-0e109896ef90" />

