### PR TITLE
Add gcp vars to validate infra

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -39,3 +39,5 @@ jobs:
           validation-plan: ${{ matrix.validation_plan }}
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
+          gcp-wip: projects/712009772377/locations/global/workloadIdentityPools/find-placement-schools/providers/find-placement-schools
+          gcp-project-id: rugged-abacus-218110


### PR DESCRIPTION
## Context

Add gcp variables to the validate-infra workflow as this is required for terraform plan

## Changes proposed in this pull request

Add variables to workflow

## Guidance to review

[test-run](https://github.com/DFE-Digital/find-placement-schools/actions/runs/25722253427/job/75526062827)
