### PR TITLE
Add support mailer

### DIFF
--- a/app/mailers/admin/user_mailer.rb
+++ b/app/mailers/admin/user_mailer.rb
@@ -1,0 +1,18 @@
+class Admin::UserMailer < ApplicationMailer
+  def user_created_notification(user)
+    notify_email to: user.email_address,
+                 subject: t(".subject", service_name:),
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   service_name:,
+                   sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "admin"),
+                 )
+  end
+
+  private
+
+  def service_name
+    t("service.name")
+  end
+end

--- a/app/wizards/add_admin_user_wizard.rb
+++ b/app/wizards/add_admin_user_wizard.rb
@@ -10,6 +10,7 @@ class AddAdminUserWizard < BaseWizard
     raise "Invalid wizard state" unless valid?
 
     user.save!
+    Admin::UserMailer.user_created_notification(user).deliver_later
     user
   end
 

--- a/config/locales/en/admin_mailer.yml
+++ b/config/locales/en/admin_mailer.yml
@@ -1,0 +1,27 @@
+en:
+  admin:
+    user_mailer:
+      user_created_notification:
+        subject: Invitation to join %{service_name}
+        body: |
+          Dear %{user_name},
+
+          You have been invited to join the %{service_name} service
+
+          # Sign in to the support site
+
+          If you have a DfE Sign-in account, you can use it to sign in:
+
+          [%{sign_in_url}](%{sign_in_url})
+
+          If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
+
+          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](%{sign_in_url}).
+
+          # Give feedback or report a problem
+
+          If you have any questions or feedback, please contact the service team.
+
+          Regards
+
+          %{service_name} team

--- a/spec/mailers/admin/user_mailer_spec.rb
+++ b/spec/mailers/admin/user_mailer_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Admin::UserMailer, type: :mailer do
+  describe "#user_created_notification" do
+    subject(:invite_email) { described_class.user_created_notification(user) }
+
+    let(:user) { create(:user, :admin) }
+    let(:slack_url) { "https://slack.example.com/support" }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("SUPPORT_SLACK_URL", "").and_return(slack_url)
+    end
+
+    it "sends invitation email" do
+      expect(invite_email.to).to contain_exactly(user.email_address)
+      expect(invite_email.subject).to eq("Invitation to join Find placement schools")
+      expect(invite_email.body.to_s.squish).to eq(<<~EMAIL.squish)
+        Dear #{user.first_name},
+
+        You have been invited to join the Find placement schools service
+
+        # Sign in to the support site
+
+        If you have a DfE Sign-in account, you can use it to sign in:
+
+        [http://localhost/sign-in?utm_campaign=admin&utm_medium=notification&utm_source=email](http://localhost/sign-in?utm_campaign=admin&utm_medium=notification&utm_source=email)
+
+        If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
+
+        After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://localhost/sign-in?utm_campaign=admin&utm_medium=notification&utm_source=email).
+
+        # Give feedback or report a problem
+
+        If you have any questions or feedback, please contact the service team.
+
+        Regards
+
+        Find placement schools team
+      EMAIL
+    end
+  end
+end

--- a/spec/mailers/admin/user_mailer_spec.rb
+++ b/spec/mailers/admin/user_mailer_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe Admin::UserMailer, type: :mailer do
     subject(:invite_email) { described_class.user_created_notification(user) }
 
     let(:user) { create(:user, :admin) }
-    let(:slack_url) { "https://slack.example.com/support" }
-
-    before do
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with("SUPPORT_SLACK_URL", "").and_return(slack_url)
-    end
 
     it "sends invitation email" do
       expect(invite_email.to).to contain_exactly(user.email_address)


### PR DESCRIPTION
## Context

When we added the support console, we were not able to add the admin invitation email.

## Changes proposed in this pull request

- Adds an invitation email for admins

## Guidance to review

- Review mailer content to ensure it is correct.

## Link to Trello card

http://trello.com/c/FJJDaG7y/273-mailer-invite-for-support-console


