### PR TITLE
Show the next academic year in June

### DIFF
--- a/app/controllers/placement_preferences_controller.rb
+++ b/app/controllers/placement_preferences_controller.rb
@@ -1,6 +1,6 @@
 class PlacementPreferencesController < ApplicationController
   def index
-    academic_years = AcademicYear.order(:starts_on).last(2)
+    academic_years = AcademicYear.for_display
     render locals: { academic_years:, organisation: current_organisation }
   end
 

--- a/app/forms/organisations/filter_form.rb
+++ b/app/forms/organisations/filter_form.rb
@@ -81,8 +81,7 @@ class Organisations::FilterForm < ApplicationForm
   end
 
   def academic_years
-    years_for_display = AcademicYear.for_display
-    AcademicYear.where(id: years_for_display.map(&:id)).order(:starts_on)
+    AcademicYear.for_display
   end
 
   private

--- a/app/forms/organisations/filter_form.rb
+++ b/app/forms/organisations/filter_form.rb
@@ -81,7 +81,8 @@ class Organisations::FilterForm < ApplicationForm
   end
 
   def academic_years
-    AcademicYear.left_outer_joins(:placement_preferences).order(:starts_on).distinct.last(2)
+    years_for_display = AcademicYear.for_display
+    AcademicYear.where(id: years_for_display.map(&:id)).order(:starts_on)
   end
 
   private

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -52,10 +52,10 @@ class AcademicYear < ApplicationRecord
     current_year = current
     return unless current_year.present?
 
-    if Date.current.month == 6
-      [ current_year, for_date(current_year.ends_on + 1.day), for_date(current_year.ends_on + 1.day + 1.year) ]
-    else
-      [ current_year, for_date(current_year.ends_on + 1.day) ]
+    display_count = Date.current.month == 6 ? 3 : 2
+
+    Array.new(display_count) do |offset|
+      for_date(current_year.starts_on + offset.years)
     end
   end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -47,4 +47,15 @@ class AcademicYear < ApplicationRecord
   def previous
     AcademicYear.for_date(starts_on - 1.year)
   end
+
+  def self.for_display
+    current_year = current
+    return unless current_year.present?
+
+    if Date.current.month == 6
+      [ current_year, for_date(current_year.ends_on + 1.day), for_date(current_year.ends_on + 1.day + 1.year) ]
+    else
+      [ current_year, for_date(current_year.ends_on + 1.day) ]
+    end
+  end
 end

--- a/spec/forms/organisations/filter_form_spec.rb
+++ b/spec/forms/organisations/filter_form_spec.rb
@@ -237,4 +237,61 @@ describe Organisations::FilterForm, type: :model do
       end
     end
   end
+
+  describe "#academic_years" do
+    subject(:filter_form) { described_class.new }
+
+    context "when the current month is not June" do
+      let!(:current_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
+               name: "2025 to 2026")
+      end
+
+      let!(:next_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2026"),
+               ends_on: Date.parse("31 August 2027"),
+               name: "2026 to 2027")
+      end
+
+      it "returns current and next academic years" do
+        Timecop.travel(Date.parse("5 December 2025")) do
+          expect(filter_form.academic_years.count).to eq(2)
+          expect(filter_form.academic_years.map(&:name)).to eq([ "2025 to 2026", "2026 to 2027" ])
+        end
+      end
+    end
+
+    context "when the current month is June" do
+      let!(:current_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2024"),
+               ends_on: Date.parse("31 August 2025"),
+               name: "2024 to 2025")
+      end
+
+      let!(:next_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
+               name: "2025 to 2026")
+      end
+
+      let!(:next_next_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2026"),
+               ends_on: Date.parse("31 August 2027"),
+               name: "2026 to 2027")
+      end
+
+      it "returns current, next, and next+1 academic years" do
+        Timecop.travel(Date.parse("15 June 2025")) do
+          expect(filter_form.academic_years.count).to eq(3)
+          expect(filter_form.academic_years.map(&:name)).to eq([ "2024 to 2025", "2025 to 2026", "2026 to 2027" ])
+        end
+      end
+    end
+  end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -108,4 +108,64 @@ RSpec.describe AcademicYear, type: :model do
       end
     end
   end
+
+  describe ".for_display" do
+    context "when the current month is not June" do
+      let!(:current_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
+               name: "2025 to 2026")
+      end
+
+      let!(:next_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2026"),
+               ends_on: Date.parse("31 August 2027"),
+               name: "2026 to 2027")
+      end
+
+      it "returns current and next academic year" do
+        Timecop.travel(Date.parse("5 December 2025")) do
+          years = described_class.for_display
+          expect(years.count).to eq(2)
+          expect(years[0]).to eq(current_academic_year)
+          expect(years[1]).to eq(next_academic_year)
+        end
+      end
+    end
+
+    context "when the current month is June" do
+      let!(:current_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2024"),
+               ends_on: Date.parse("31 August 2025"),
+               name: "2024 to 2025")
+      end
+
+      let!(:next_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
+               name: "2025 to 2026")
+      end
+
+      let!(:next_next_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2026"),
+               ends_on: Date.parse("31 August 2027"),
+               name: "2026 to 2027")
+      end
+
+      it "returns current, next, and next+1 academic years" do
+        Timecop.travel(Date.parse("15 June 2025")) do
+          years = described_class.for_display
+          expect(years.count).to eq(3)
+          expect(years[0]).to eq(current_academic_year)
+          expect(years[1]).to eq(next_academic_year)
+          expect(years[2]).to eq(next_next_academic_year)
+        end
+      end
+    end
+  end
 end

--- a/spec/system/placement_preferences/school_user_views_academic_years_in_june_spec.rb
+++ b/spec/system/placement_preferences/school_user_views_academic_years_in_june_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "School user views academic years in June", type: :system do
       "Status" => "No information added"
     })
     expect(page).to have_table_row({
-      "Academic year" => AcademicYear.for_display.last.name,
+      "Academic year" => "2026 to 2027",
       "Status" => "No information added"
     })
   end

--- a/spec/system/placement_preferences/school_user_views_academic_years_in_june_spec.rb
+++ b/spec/system/placement_preferences/school_user_views_academic_years_in_june_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "School user views academic years in June", type: :system do
+  scenario "School user sees three academic years in June" do
+    Timecop.travel(Date.parse("15 June 2025")) do
+      given_academic_years_exist
+      when_i_am_signed_in
+      when_i_navigate_to_placement_preferences
+      then_i_see_three_academic_years_displayed
+    end
+  end
+
+  scenario "School user sees two academic years outside June" do
+    Timecop.travel(Date.parse("15 December 2025")) do
+      given_academic_years_exist
+      when_i_am_signed_in
+      when_i_navigate_to_placement_preferences
+      then_i_see_two_academic_years_displayed
+    end
+  end
+
+  private
+
+  def given_academic_years_exist
+    @current_academic_year = AcademicYear.current
+    @next_academic_year = AcademicYear.next
+  end
+
+  def when_i_am_signed_in
+    @school = build(:school, name: "Hogwarts")
+    create(:placement_preference,
+           organisation: @school,
+           academic_year: @current_academic_year,
+           appetite: "actively_looking")
+    sign_in_user(organisations: [ @school ])
+  end
+
+  def when_i_navigate_to_placement_preferences
+    within(service_navigation) do
+      click_on "Placement information"
+    end
+  end
+
+  def then_i_see_three_academic_years_displayed
+    expect(page).to have_title("Placement information - Find placement schools")
+    expect(page).to have_table_row({
+      "Academic year" => @current_academic_year.name,
+      "Status" => "Offering placements"
+    })
+    expect(page).to have_table_row({
+      "Academic year" => @next_academic_year.name,
+      "Status" => "No information added"
+    })
+    expect(page).to have_table_row({
+      "Academic year" => AcademicYear.for_display.last.name,
+      "Status" => "No information added"
+    })
+  end
+
+  def then_i_see_two_academic_years_displayed
+    expect(page).to have_title("Placement information - Find placement schools")
+    expect(page).to have_table_row({
+      "Academic year" => @current_academic_year.name,
+      "Status" => "Offering placements"
+    })
+    expect(page).to have_table_row({
+      "Academic year" => @next_academic_year.name,
+      "Status" => "No information added"
+    })
+    expect(page).to have_css("tbody tr", count: 2)
+  end
+end


### PR DESCRIPTION
## Context

When we hit June, we want to update to the next academic year, rather than following the traditional September roll over.

## Changes proposed in this pull request

- [x] Roll over the academic year in June
- [x] Display the next two academic years, rather than one.

## Guidance to review

- On local development log in as Anne and make some placements for the next two acadmic years
- Then log in as Patricia and verify they are displaying correctly.

## Link to Trello card

https://trello.com/c/aEEeAL7f/472-automate-adding-future-academic-years-2-years-on-1-june

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
